### PR TITLE
Make collections sanity tests pass using ansible 2.9.X

### DIFF
--- a/awx_collection/plugins/module_utils/controller_module.py
+++ b/awx_collection/plugins/module_utils/controller_module.py
@@ -32,12 +32,35 @@ class ItemNotDefined(Exception):
 class ControllerModule(AnsibleModule):
     url = None
     AUTH_ARGSPEC = dict(
-        controller_host=dict(required=False, aliases=['tower_host'], fallback=(env_fallback, ['CONTROLLER_HOST', 'TOWER_HOST'])),
-        controller_username=dict(required=False, aliases=['tower_username'], fallback=(env_fallback, ['CONTROLLER_USERNAME', 'TOWER_USERNAME'])),
-        controller_password=dict(no_log=True, aliases=['tower_password'], required=False, fallback=(env_fallback, ['CONTROLLER_PASSWORD', 'TOWER_PASSWORD'])),
-        validate_certs=dict(type='bool', aliases=['tower_verify_ssl'], required=False, fallback=(env_fallback, ['CONTROLLER_VERIFY_SSL', 'TOWER_VERIFY_SSL'])),
-        controller_oauthtoken=dict(type='raw', no_log=True, aliases=['tower_oauthtoken'], required=False, fallback=(env_fallback, ['CONTROLLER_OAUTH_TOKEN', 'TOWER_OAUTH_TOKEN'])),
-        controller_config_file=dict(type='path', aliases=['tower_config_file'], required=False, default=None),
+        controller_host=dict(
+            required=False,
+            aliases=['tower_host'],
+            fallback=(env_fallback, ['CONTROLLER_HOST', 'TOWER_HOST'])),
+        controller_username=dict(
+            required=False,
+            aliases=['tower_username'],
+            fallback=(env_fallback, ['CONTROLLER_USERNAME', 'TOWER_USERNAME'])),
+        controller_password=dict(
+            no_log=True,
+            aliases=['tower_password'],
+            required=False,
+            fallback=(env_fallback, ['CONTROLLER_PASSWORD', 'TOWER_PASSWORD'])),
+        validate_certs=dict(
+            type='bool',
+            aliases=['tower_verify_ssl'],
+            required=False,
+            fallback=(env_fallback, ['CONTROLLER_VERIFY_SSL', 'TOWER_VERIFY_SSL'])),
+        controller_oauthtoken=dict(
+            type='raw',
+            no_log=True,
+            aliases=['tower_oauthtoken'],
+            required=False,
+            fallback=(env_fallback, ['CONTROLLER_OAUTH_TOKEN', 'TOWER_OAUTH_TOKEN'])),
+        controller_config_file=dict(
+            type='path',
+            aliases=['tower_config_file'],
+            required=False,
+            default=None),
     )
     short_params = {
         'host': 'controller_host',

--- a/awx_collection/tests/sanity/ignore-2.9.txt
+++ b/awx_collection/tests/sanity/ignore-2.9.txt
@@ -1,9 +1,3 @@
-plugins/modules/receive.py validate-modules:deprecation-mismatch
-plugins/modules/receive.py validate-modules:invalid-documentation
-plugins/modules/send.py validate-modules:deprecation-mismatch
-plugins/modules/send.py validate-modules:invalid-documentation
-plugins/modules/workflow_template.py validate-modules:deprecation-mismatch
-plugins/modules/workflow_template.py validate-modules:invalid-documentation
 plugins/inventory/controller.py pylint:raise-missing-from
 plugins/inventory/controller.py pylint:super-with-arguments
 plugins/lookup/schedule_rrule.py pylint:raise-missing-from


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Made corrections to the collections package so that the Ansible `2.9.21` sanity tests pass

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.1.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

The ansible-test binary was installed via `dnf` on a Fedora 34 machine. 

##### STEPS TO REPRODUCE:

1. Install the `ansible-test` binary (for example `sudo dnf install ansible-test-2.9.21`) or in a virtual environment
2. Checkout AWX project from git
3. Inside the AWX folder, run `make install_collection`
4. Navigate to collections installation directory (ie. `~/.ansible/collections/ansible_collections/awx/awx` by default)
5. Execute `ansible-test sanity` and analyze outputs

<!--- Paste verbatim command output below, e.g. before and after your change -->
